### PR TITLE
Give a name to spawned threads

### DIFF
--- a/src/music.rs
+++ b/src/music.rs
@@ -184,7 +184,8 @@ impl Music {
         self.looping_sender = Some(looping_sender);
         let is_looping_clone = self.is_looping.clone();
 
-        self.thread_handle = Some(thread::spawn(move|| {
+        let thread = thread::Builder::new().name(String::from("ears-music"));
+        self.thread_handle = Some(thread.spawn(move|| {
             match OpenAlData::check_al_context() {
                 Ok(_)       => {},
                 Err(err)    => { println!("{}", err);}
@@ -233,7 +234,7 @@ impl Music {
                 status = al::alGetState(al_source);
             }
             al::alSourcei(al_source, ffi::AL_BUFFER, 0);
-        }));
+        }).unwrap());
         let file = self.file.as_ref().unwrap().clone();
         chan.send(*file);
     }

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -90,7 +90,8 @@ impl Recorder {
         self.stop_sender = Some(stop_sender);
         self.data_receiver = Some(data_receiver);
 
-        thread::spawn(move || {
+        let thread = thread::Builder::new().name(String::from("ears-recorder"));
+        thread.spawn(move || {
             let mut terminate = false;
             let ctxt = record_context::get(r_c);
             unsafe { ffi::alcCaptureStart(ctxt); }
@@ -124,7 +125,7 @@ impl Recorder {
                 }
             }
             data_sender.send(samples);
-        });
+        }).unwrap();
     }
 
     pub fn stop(&mut self) -> bool {


### PR DESCRIPTION
It helps when debugging which thread is which in a random program.