### PR TITLE
Add a getter and setter for the offset in seconds in the sound

### DIFF
--- a/src/audio_controller.rs
+++ b/src/audio_controller.rs
@@ -51,6 +51,22 @@ pub trait AudioController {
     fn get_state(&self) -> State;
 
     /**
+     * Set the playback position in the Music.
+     *
+     * # Argument
+     * * `offset` - The time at which to seek, in seconds
+     */
+    fn set_offset(&mut self, offset: f32) -> ();
+
+    /**
+     * Get the current position in the Music.
+     *
+     * # Return
+     * The time at which the Music is currently playing
+     */
+    fn get_offset(&self) -> f32;
+
+    /**
      * Set the volume of the Audio Source.
      *
      * A value of 1.0 means unattenuated. Each division by 2 equals an attenuation

--- a/src/music.rs
+++ b/src/music.rs
@@ -69,7 +69,7 @@ pub struct Music {
     /// Information of the file
     file_infos: SndInfo,
     /// Quantity of sample to read each time
-    sample_to_read: i32,
+    sample_to_read: i64,
     /// Format of the sample
     sample_format: i32,
     /// Audio tags
@@ -134,8 +134,8 @@ impl Music {
             al_source: source_id,
             al_buffers: buffer_ids,
             file: Some(file),
+            sample_to_read: 2 * infos.frames,
             file_infos: infos,
-            sample_to_read: 50000,
             sample_format: format,
             sound_tags: sound_tags,
             is_looping: false,
@@ -157,7 +157,7 @@ impl Music {
 
         // full buff1
         let mut len = mem::size_of::<i16>() *
-            self.file.as_mut().unwrap().read_i16(&mut samples[..], sample_t_r as i64) as usize;
+            self.file.as_mut().unwrap().read_i16(&mut samples[..], sample_t_r) as usize;
         al::alBufferData(al_buffers[0],
                          sample_format,
                          samples.as_ptr() as *mut c_void,
@@ -167,7 +167,7 @@ impl Music {
         // full buff2
         samples.clear();
         len = mem::size_of::<i16>() *
-            self.file.as_mut().unwrap().read_i16(&mut samples[..], sample_t_r as i64) as usize;
+            self.file.as_mut().unwrap().read_i16(&mut samples[..], sample_t_r) as usize;
         al::alBufferData(al_buffers[1],
                          sample_format,
                          samples.as_ptr() as *mut c_void,
@@ -208,10 +208,10 @@ impl Music {
                                      &mut buffers_processed);
                     if buffers_processed != 0 {
                         al::alSourceUnqueueBuffers(al_source, 1, &mut buf);
-                        let read = file.read_i16(&mut samples[..], sample_t_r as i64);
+                        let read = file.read_i16(&mut samples[..], sample_t_r);
 
-                        if is_looping && read < sample_t_r as i64 {
-                            let additional_read = sample_t_r as i64 - read;
+                        if is_looping && read < sample_t_r {
+                            let additional_read = sample_t_r - read;
 
                             file.seek(0, SeekSet);
                             file.read_i16(&mut samples[read as usize..], additional_read);

--- a/src/music.rs
+++ b/src/music.rs
@@ -325,6 +325,32 @@ impl AudioController for Music {
     }
 
     /**
+     * Set the playback position in the Music.
+     *
+     * # Argument
+     * * `offset` - The time at which to seek, in seconds
+     */
+    fn set_offset(&mut self, offset: f32) -> () {
+        check_openal_context!(());
+
+        al::alSourcef(self.al_source, ffi::AL_SEC_OFFSET, offset);
+    }
+
+    /**
+     * Get the current position in the Music.
+     *
+     * # Return
+     * The time at which the Music is currently playing
+     */
+    fn get_offset(&self) -> f32 {
+        check_openal_context!(0.);
+
+        let mut offset : f32 = 0.;
+        al::alGetSourcef(self.al_source, ffi::AL_SEC_OFFSET, &mut offset);
+        offset
+    }
+
+    /**
      * Set the volume of the Music.
      *
      * A value of 1.0 means unattenuated. Each division by 2 equals an attenuation

--- a/src/openal.rs
+++ b/src/openal.rs
@@ -56,6 +56,7 @@ pub mod ffi {
     pub const AL_MAX_DISTANCE:        i32         = 0x1023;
     pub const AL_REFERENCE_DISTANCE:  i32         = 0x1020;
     pub const AL_ROLLOFF_FACTOR:      i32         = 0x1021;
+    pub const AL_SEC_OFFSET:          i32         = 0x1024;
 
     /// Sound format
     pub const AL_FORMAT_MONO16:       i32         = 0x1101;

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -327,6 +327,32 @@ impl AudioController for Sound {
     }
 
     /**
+     * Set the playback position in the Music.
+     *
+     * # Argument
+     * * `offset` - The time at which to seek, in seconds
+     */
+    fn set_offset(&mut self, offset: f32) -> () {
+        check_openal_context!(());
+
+        al::alSourcef(self.al_source, ffi::AL_SEC_OFFSET, offset);
+    }
+
+    /**
+     * Get the current position in the Music.
+     *
+     * # Return
+     * The time at which the Music is currently playing
+     */
+    fn get_offset(&self) -> f32 {
+        check_openal_context!(0.);
+
+        let mut offset : f32 = 0.;
+        al::alGetSourcef(self.al_source, ffi::AL_SEC_OFFSET, &mut offset);
+        offset
+    }
+
+    /**
      * Set the volume of the Sound.
      *
      * A value of 1.0 means unattenuated. Each division by 2 equals an


### PR DESCRIPTION
These use a `f32` for the time in seconds, which should be enough for any music file.  It may be useful to provide another function giving samples back (using `AL_SAMPLE_OFFSET` instead of `AL_SEC_OFFSET`), but so far I haven’t encountered the need for it.