### PR TITLE
Bump lazy_static to version 1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ crate-type = ["dylib", "rlib"]
 
 [dependencies]
 libc = "0.2"
-lazy_static = "0.2"
+lazy_static = "1"
 
 [badges]
 appveyor = { repository = "nickbrowne/ears", branch = "master" }


### PR DESCRIPTION
Fixes a warning about using `std::sync::ONCE_INIT`.