### PR TITLE
Use pkg-config on Unix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ crate-type = ["dylib", "rlib"]
 libc = "0.2"
 lazy_static = "0.2"
 
+[build-dependencies]
+pkg-config = "0.3"
+
 [badges]
 appveyor = { repository = "nickbrowne/ears", branch = "master" }
 travis-ci = { repository = "nickbrowne/ears", branch = "master" }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,22 @@
 #[cfg(unix)]
+extern crate pkg_config;
+
+#[cfg(unix)]
 fn main() {
-    println!("cargo:rustc-link-search=native=/usr/local/opt/openal-soft/lib");
-    println!("cargo:rustc-link-search=native=/usr/local/lib");
+    for name in ["openal", "sndfile"].iter() {
+        let lib = pkg_config::Config::new()
+            .print_system_libs(false)
+            .find(name)
+            .unwrap();
+
+        for include in lib.include_paths.iter() {
+            println!("cargo:include={}", include.display());
+        }
+
+        for link in lib.link_paths.iter() {
+            println!("cargo:rustc-link-search=native={}", link.display());
+        }
+    }
 }
 
 #[cfg(all(windows, target_arch = "x86"))]


### PR DESCRIPTION
This tool uses the .pc files shipped with each library to locate the
include and link directories.  That way it works no matter where the
distribution or admin installed each library.

This replaces the very uncommon /usr/local/opt directory that was
previously used.