### PR TITLE
Use structs or enums for all functions returning a Result

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,51 @@
+use openal::al;
+use sndfile::SndFileError;
+use std::error::Error;
+use std::fmt;
+
+/// All possible errors when opening a Sound or Music.
+pub enum SoundError {
+    /// Happens when OpenAL failed to load for some reason.
+    InvalidOpenALContext,
+
+    /// Error while loading music file.
+    LoadError(SndFileError),
+
+    /// Unrecognized music format.
+    InvalidFormat,
+
+    /// Internal OpenAL error.
+    InternalOpenALError(al::AlError),
+}
+
+impl fmt::Display for SoundError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "{}",
+            match self {
+                SoundError::InvalidOpenALContext => "invalid OpenAL context".to_string(),
+                SoundError::LoadError(err) => format!("error while loading music file: {}", err),
+                SoundError::InvalidFormat => "unrecognized music format".to_string(),
+                SoundError::InternalOpenALError(err) => format!("internal OpenAL error: {}", err),
+            }
+        )
+    }
+}
+
+impl fmt::Debug for SoundError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, fmt)
+    }
+}
+
+impl Error for SoundError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            SoundError::InvalidOpenALContext => None,
+            SoundError::LoadError(err) => Some(err),
+            SoundError::InvalidFormat => None,
+            SoundError::InternalOpenALError(err) => Some(err),
+        }
+    }
+}

--- a/src/init.rs
+++ b/src/init.rs
@@ -28,21 +28,21 @@
  * and destroyed in a another task.
  */
 
-use internal::OpenAlData;
+use internal::{OpenAlContextError, OpenAlData};
 use record_context::RecordContext;
 
 /**
  * Initialize the internal context
  *
  * # Return
- * `Ok(())` if initialization is successful, `Err(String)` otherwise
+ * `Ok(())` if initialization is successful, `Err(OpenAlContextError)` otherwise
  *
  * # Example
  * ```no_run
  * ears::init().unwrap()
  * ```
  */
-pub fn init() -> Result<(), String> {
+pub fn init() -> Result<(), OpenAlContextError> {
     return OpenAlData::check_al_context();
 }
 
@@ -50,14 +50,14 @@ pub fn init() -> Result<(), String> {
  * Initialize the input device context
  *
  * # Return
- * `Ok(RecordContext)` if initialization is successful, `Err(String)` otherwise
+ * `Ok(RecordContext)` if initialization is successful, `Err(OpenAlContextError)` otherwise
  *
  * # Example
  * ```no_run
  * ears::init_in().unwrap();
  * ```
  */
-pub fn init_in() -> Result<RecordContext, String> {
+pub fn init_in() -> Result<RecordContext, OpenAlContextError> {
     return OpenAlData::check_al_input_context();
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ mod audio_controller;
 mod audio_tags;
 #[path = "init.rs"]
 mod einit;
+mod error;
 pub mod listener;
 mod music;
 mod presets;

--- a/src/reverb_effect.rs
+++ b/src/reverb_effect.rs
@@ -231,8 +231,8 @@ impl Drop for ReverbEffect {
         // Check if there is OpenAL internal error
         //
         // TODO: this could probably be avoided with some better design
-        if al::openal_has_error().is_some() {
-            eprintln!("Ears failed to drop ReverbEffect completely, one or more source is probably still referencing it.");
+        if let Some(err) = al::openal_has_error() {
+            eprintln!("Ears failed to drop ReverbEffect completely, one or more source is probably still referencing it: {}", err);
             eprintln!("\tEffect Object: {}", self.effect_id);
             eprintln!("\tAuxiliary Effect Slot: {}", self.effect_slot_id);
         };

--- a/src/reverb_effect.rs
+++ b/src/reverb_effect.rs
@@ -1,6 +1,46 @@
 use internal::OpenAlData;
 use openal::{al, ffi};
 use presets::ReverbProperties;
+use std::error::Error;
+use std::fmt;
+
+/// All possible errors when opening a Music.
+pub enum ReverbEffectError {
+    /// Happens when OpenAL failed to load for some reason.
+    InvalidOpenALContext,
+
+    /// Internal OpenAL error.
+    InternalOpenALError(al::AlError),
+}
+
+impl fmt::Display for ReverbEffectError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            fmt,
+            "{}",
+            match self {
+                ReverbEffectError::InvalidOpenALContext => "invalid OpenAL context".to_string(),
+                ReverbEffectError::InternalOpenALError(err) =>
+                    format!("internal OpenAL error: {}", err),
+            }
+        )
+    }
+}
+
+impl fmt::Debug for ReverbEffectError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt::Display::fmt(self, fmt)
+    }
+}
+
+impl Error for ReverbEffectError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            ReverbEffectError::InvalidOpenALContext => None,
+            ReverbEffectError::InternalOpenALError(err) => Some(err),
+        }
+    }
+}
 
 /**
  * Create and configure reverb effects.
@@ -49,8 +89,8 @@ pub struct ReverbEffect {
 }
 
 impl ReverbEffect {
-    pub fn new() -> Result<ReverbEffect, String> {
-        check_openal_context!(Err("Invalid OpenAL context.".into()));
+    pub fn new() -> Result<ReverbEffect, ReverbEffectError> {
+        check_openal_context!(Err(ReverbEffectError::InvalidOpenALContext));
 
         // Can't seem to find a way to query whether or not EFX extension is available
         // or not... or if that's even necessary, so just assume it's available
@@ -69,7 +109,7 @@ impl ReverbEffect {
 
         // Check if there is OpenAL internal error
         if let Some(err) = al::openal_has_error() {
-            return Err(format!("ReverbEffect::new - OpenAL error: {}", err));
+            return Err(ReverbEffectError::InternalOpenALError(err));
         };
 
         Ok(ReverbEffect {
@@ -78,7 +118,7 @@ impl ReverbEffect {
         })
     }
 
-    pub fn preset(reverb_properties: ReverbProperties) -> Result<ReverbEffect, String> {
+    pub fn preset(reverb_properties: ReverbProperties) -> Result<ReverbEffect, ReverbEffectError> {
         match Self::new() {
             Ok(mut effect) => {
                 effect.set_density(reverb_properties.density);
@@ -97,7 +137,7 @@ impl ReverbEffect {
 
                 // Check if there is OpenAL internal error
                 if let Some(err) = al::openal_has_error() {
-                    return Err(format!("ReverbEffect::preset - OpenAL error: {}", err));
+                    return Err(ReverbEffectError::InternalOpenALError(err));
                 };
 
                 effect.update_slot();

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -288,7 +288,7 @@ impl AudioController for Sound {
 
         match al::openal_has_error() {
             None => {}
-            Some(err) => println!("{}", err),
+            Some(err) => println!("Internal OpenAL error: {}", err),
         }
     }
 

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -27,6 +27,7 @@ use std::time::Duration;
 
 use audio_controller::AudioController;
 use audio_tags::{AudioTags, Tags};
+use error::SoundError;
 use internal::OpenAlData;
 use openal::{al, ffi};
 use reverb_effect::ReverbEffect;
@@ -76,7 +77,7 @@ impl Sound {
      * `path` - The path of the sound file to create the SoundData.
      *
      * # Return
-     * A `Result` containing Ok(Sound) on success, Err(String)
+     * A `Result` containing Ok(Sound) on success, Err(SoundError)
      * if there has been an error.
      *
      * # Example
@@ -87,16 +88,11 @@ impl Sound {
      *                  .expect("Cannot load the sound from a file!");
      * ```
      */
-    pub fn new(path: &str) -> Result<Sound, String> {
-        check_openal_context!(Err("Invalid OpenAL context.".into()));
+    pub fn new(path: &str) -> Result<Sound, SoundError> {
+        check_openal_context!(Err(SoundError::InvalidOpenALContext));
 
-        let sound_data = match SoundData::new(path) {
-            Ok(data) => Rc::new(RefCell::new(data)),
-            Err(err) => {
-                return Err(format!("Error creating sound data: {}", err));
-            }
-        };
-
+        let sound_data = SoundData::new(path)?;
+        let sound_data = Rc::new(RefCell::new(sound_data));
         Sound::new_with_data(sound_data)
     }
 
@@ -120,8 +116,8 @@ impl Sound {
      * let sound = Sound::new_with_data(data).unwrap();
      * ```
      */
-    pub fn new_with_data(sound_data: Rc<RefCell<SoundData>>) -> Result<Sound, String> {
-        check_openal_context!(Err("Invalid OpenAL context.".into()));
+    pub fn new_with_data(sound_data: Rc<RefCell<SoundData>>) -> Result<Sound, SoundError> {
+        check_openal_context!(Err(SoundError::InvalidOpenALContext));
 
         let mut source_id = 0;
         // create the source
@@ -135,7 +131,7 @@ impl Sound {
 
         // Check if there is OpenAL internal error
         if let Some(err) = al::openal_has_error() {
-            return Err(format!("Internal OpenAL error: {}", err));
+            return Err(SoundError::InternalOpenALError(err));
         };
 
         Ok(Sound {


### PR DESCRIPTION
Returning a `String` prevents the result from being understandable by a machine, whereas some programs might want to react differently to different errors.

This PR makes all `Err` results return a proper error `struct` or `enum`.