### PR TITLE
Run rustfmt during CI on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,10 @@ addons:
     packages:
     - libopenal-dev
     - libsndfile1-dev
+before_script:
+- |
+  [ $TRAVIS_RUST_VERSION = nightly ] || rustup component add rustfmt
 script:
+- |
+  [ $TRAVIS_RUST_VERSION = nightly ] || cargo fmt -- --check
 - cargo test


### PR DESCRIPTION
This helps contributors know how to keep the codebase well-formed.  If it is deemed useful to ignore styling for a block or a file though, we can always use `#[rustfmt::skip]` or `#![rustfmt::skip]`.