### PR TITLE
Replace all .unwrap() with ? in docstrings

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -39,7 +39,10 @@ use record_context::RecordContext;
  *
  * # Example
  * ```no_run
- * ears::init().unwrap()
+ * fn main() -> Result<(), ears::OpenAlContextError> {
+ *     ears::init()?;
+ *     Ok(())
+ * }
  * ```
  */
 pub fn init() -> Result<(), OpenAlContextError> {
@@ -54,7 +57,10 @@ pub fn init() -> Result<(), OpenAlContextError> {
  *
  * # Example
  * ```no_run
- * ears::init_in().unwrap();
+ * fn main() -> Result<(), ears::OpenAlContextError> {
+ *     ears::init_in()?;
+ *     Ok(())
+ * }
  * ```
  */
 pub fn init_in() -> Result<RecordContext, OpenAlContextError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,17 +35,19 @@ A simple library to play sounds and music in Rust, using OpenAL and libsndfile.
 
 ```no_run
 extern crate ears;
-use ears::{Sound, AudioController};
+use ears::{Sound, SoundError, AudioController};
 
-fn main() {
+fn main() -> Result<(), SoundError> {
     // Create a new Sound.
-    let mut snd = Sound::new("path/to/my/sound.ogg").unwrap();
+    let mut snd = Sound::new("path/to/my/sound.ogg")?;
 
     // Play the Sound
     snd.play();
 
     // Wait until the end of the sound
     while snd.is_playing() {}
+
+    Ok(())
 }
 ```
 */

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,8 @@ extern crate lazy_static;
 pub use audio_controller::AudioController;
 pub use audio_tags::{AudioTags, Tags};
 pub use einit::{init, init_in};
+pub use error::SoundError;
+pub use internal::OpenAlContextError;
 pub use music::Music;
 pub use presets::ReverbPreset;
 pub use record_context::RecordContext;

--- a/src/music.rs
+++ b/src/music.rs
@@ -62,11 +62,12 @@ const BUFFER_COUNT: i32 = 2;
  * # Examples
  * ```no_run
  * extern crate ears;
- * use ears::{Music, AudioController};
+ * use ears::{Music, SoundError, AudioController};
  *
- * fn main() -> () {
- *   let mut msc = Music::new("path/to/music.flac").unwrap();
+ * fn main() -> Result<(), SoundError> {
+ *   let mut msc = Music::new("path/to/music.flac")?;
  *   msc.play();
+ *   Ok(())
  * }
  * ```
  */

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -46,9 +46,9 @@ use std::intrinsics::transmute;
  * ```no_run
  * use ears::Recorder;
  *
- * fn main() -> () {
+ * fn main() -> Result<(), ears::OpenAlContextError> {
  *     // Create a new context to record audio
- *     let context = ears::init_in().unwrap();
+ *     let context = ears::init_in()?;
  *     // Create the recorder
  *     let mut recorder = Recorder::new(context);
  *     // Start to record something
@@ -60,6 +60,8 @@ use std::intrinsics::transmute;
  *     recorder.stop();
  *     // Then store the recorded data in a file
  *     recorder.save_to_file("hello_file");
+ *
+ *     Ok(())
  * }
  * ```
  */

--- a/src/reverb_effect.rs
+++ b/src/reverb_effect.rs
@@ -60,14 +60,14 @@ impl Error for ReverbEffectError {
  * # Examples
  * ```no_run
  * extern crate ears;
- * use ears::{ReverbEffect, ReverbPreset, Sound, AudioController};
+ * use ears::{ReverbEffect, ReverbPreset, Sound, SoundError, AudioController};
  *
- * fn main() -> () {
+ * fn main() -> Result<(), SoundError> {
  *    // Create an effect (in this case, using a preset)
  *    let effect = ReverbEffect::preset(ReverbPreset::Cave.properties()).ok();
  *
  *    // Create a Sound with the path of the sound file.
- *    let mut sound = Sound::new("path/to/my/sound.ogg").unwrap();
+ *    let mut sound = Sound::new("path/to/my/sound.ogg")?;
  *
  *    // Connect the sound to the effect
  *    sound.connect(&effect);
@@ -80,6 +80,7 @@ impl Error for ReverbEffectError {
  *
  *    // If you want to disconnect an Effect, just pass None
  *    sound.connect(&None);
+ *    Ok(())
  * }
  * ```
  */

--- a/src/sound.rs
+++ b/src/sound.rs
@@ -46,17 +46,19 @@ use states::State::{Initial, Paused, Playing, Stopped};
  * # Examples
  * ```no_run
  * extern crate ears;
- * use ears::{Sound, AudioController};
+ * use ears::{Sound, AudioController, SoundError};
  *
- * fn main() -> () {
+ * fn main() -> Result<(), SoundError> {
  *    // Create a Sound with the path of the sound file.
- *    let mut snd = Sound::new("path/to/my/sound.ogg").unwrap();
+ *    let mut snd = Sound::new("path/to/my/sound.ogg")?;
  *
  *    // Play it
  *    snd.play();
  *
  *    // Wait until the sound stopped playing
  *    while snd.is_playing() {}
+ *
+ *    Ok(())
  * }
  * ```
  */
@@ -108,12 +110,15 @@ impl Sound {
      *
      * # Example
      * ```ignore
-     * use ears::{Sound, SoundData, AudioController};
+     * use ears::{Sound, SoundData, SoundError, AudioController};
      * use std::rc::Rc;
      * use std::cell::RefCell;
      *
-     * let data = Rc::new(RefCell::new(SoundData::new("path/to/the/sound.ogg").unwrap()))
-     * let sound = Sound::new_with_data(data).unwrap();
+     * fn main() -> Result<(), SoundError> {
+     *     let data = Rc::new(RefCell::new(SoundData::new("path/to/the/sound.ogg")?));
+     *     let sound = Sound::new_with_data(data)?;
+     *     Ok(())
+     * }
      * ```
      */
     pub fn new_with_data(sound_data: Rc<RefCell<SoundData>>) -> Result<Sound, SoundError> {
@@ -148,8 +153,11 @@ impl Sound {
      *
      * # Example
      * ```no_run
-     * let snd = ears::Sound::new("path/to/the/sound.ogg").unwrap();
-     * let snd_data = snd.get_datas();
+     * fn main() -> Result<(), ears::SoundError> {
+     *     let snd = ears::Sound::new("path/to/the/sound.ogg")?;
+     *     let snd_data = snd.get_datas();
+     *     Ok(())
+     * }
      * ```
      */
     pub fn get_datas(&self) -> Rc<RefCell<SoundData>> {
@@ -166,10 +174,13 @@ impl Sound {
      *
      * # Example
      * ```no_run
-     * let snd1 = ears::Sound::new("path/to/the/sound.ogg").unwrap();
-     * let mut snd2 = ears::Sound::new("other/path/to/the/sound.ogg").unwrap();
-     * let snd_data = snd1.get_datas();
-     * snd2.set_datas(snd_data);
+     * fn main() -> Result<(), ears::SoundError> {
+     *     let snd1 = ears::Sound::new("path/to/the/sound.ogg")?;
+     *     let mut snd2 = ears::Sound::new("other/path/to/the/sound.ogg")?;
+     *     let snd_data = snd1.get_datas();
+     *     snd2.set_datas(snd_data);
+     *     Ok(())
+     * }
      * ```
      */
     pub fn set_datas(&mut self, sound_data: Rc<RefCell<SoundData>>) {
@@ -271,10 +282,13 @@ impl AudioController for Sound {
      *
      * # Example
      * ```no_run
-     * use ears::{Sound, AudioController};
+     * use ears::{Sound, SoundError, AudioController};
      *
-     * let mut snd = Sound::new("path/to/the/sound.ogg").unwrap();
-     * snd.play();
+     * fn main() -> Result<(), SoundError> {
+     *     let mut snd = Sound::new("path/to/the/sound.ogg")?;
+     *     snd.play();
+     *     Ok(())
+     * }
      * ```
      */
     fn play(&mut self) -> () {
@@ -293,12 +307,15 @@ impl AudioController for Sound {
      *
      * # Example
      * ```no_run
-     * use ears::{Sound, AudioController};
+     * use ears::{Sound, SoundError, AudioController};
      *
-     * let mut snd = Sound::new("path/to/the/sound.ogg").unwrap();
-     * snd.play();
-     * snd.pause();
-     * snd.play(); // the sound restarts at the moment of the pause
+     * fn main() -> Result<(), SoundError> {
+     *     let mut snd = Sound::new("path/to/the/sound.ogg")?;
+     *     snd.play();
+     *     snd.pause();
+     *     snd.play(); // the sound restarts at the moment of the pause
+     *     Ok(())
+     * }
      * ```
      */
     fn pause(&mut self) -> () {
@@ -312,12 +329,15 @@ impl AudioController for Sound {
      *
      * # Example
      * ```no_run
-     * use ears::{Sound, AudioController};
+     * use ears::{Sound, SoundError, AudioController};
      *
-     * let mut snd = Sound::new("path/to/the/sound.ogg").unwrap();
-     * snd.play();
-     * snd.stop();
-     * snd.play(); // the sound restart at the begining
+     * fn main() -> Result<(), SoundError> {
+     *     let mut snd = Sound::new("path/to/the/sound.ogg")?;
+     *     snd.play();
+     *     snd.stop();
+     *     snd.play(); // the sound restart at the begining
+     *     Ok(())
+     * }
      * ```
      */
     fn stop(&mut self) -> () {
@@ -331,11 +351,14 @@ impl AudioController for Sound {
      *
      * # Example
      * ```no_run
-     * use ears::{Sound, ReverbEffect, ReverbPreset, AudioController};
+     * use ears::{Sound, SoundError, ReverbEffect, ReverbPreset, AudioController};
      *
-     * let reverb_effect = ReverbEffect::preset(ReverbPreset::Sewerpipe.properties()).ok();
-     * let mut snd = Sound::new("path/to/sound.ogg").unwrap();
-     * snd.connect(&reverb_effect);
+     * fn main() -> Result<(), SoundError> {
+     *     let reverb_effect = ReverbEffect::preset(ReverbPreset::Sewerpipe.properties()).ok();
+     *     let mut snd = Sound::new("path/to/sound.ogg")?;
+     *     snd.connect(&reverb_effect);
+     *     Ok(())
+     * }
      * ```
      */
     fn connect(&mut self, reverb_effect: &Option<ReverbEffect>) {
@@ -371,14 +394,17 @@ impl AudioController for Sound {
      *
      * # Example
      * ```no_run
-     * use ears::{Sound, AudioController};
+     * use ears::{Sound, SoundError, AudioController};
      *
-     * let mut snd = Sound::new("path/to/the/sound.ogg").unwrap();
-     * snd.play();
-     * if snd.is_playing() {
-     *     println!("Sound is Playing !");
-     * } else {
-     *     println!("Sound is Pause or Stopped !");
+     * fn main() -> Result<(), SoundError> {
+     *     let mut snd = Sound::new("path/to/the/sound.ogg")?;
+     *     snd.play();
+     *     if snd.is_playing() {
+     *         println!("Sound is Playing !");
+     *     } else {
+     *         println!("Sound is Pause or Stopped !");
+     *     }
+     *     Ok(())
      * }
      * ```
      */
@@ -397,14 +423,17 @@ impl AudioController for Sound {
      *
      * # Example
      * ```no_run
-     * use ears::{Sound, State, AudioController};
+     * use ears::{Sound, SoundError, State, AudioController};
      *
-     * let snd = Sound::new("path/to/the/sound.ogg").unwrap();
-     * match snd.get_state() {
-     *     State::Initial => println!("Sound has never been played"),
-     *     State::Playing => println!("Sound is playing!"),
-     *     State::Paused  => println!("Sound is paused!"),
-     *     State::Stopped => println!("Sound is stopped!")
+     * fn main() -> Result<(), SoundError> {
+     *     let snd = Sound::new("path/to/the/sound.ogg")?;
+     *     match snd.get_state() {
+     *         State::Initial => println!("Sound has never been played"),
+     *         State::Playing => println!("Sound is playing!"),
+     *         State::Paused  => println!("Sound is paused!"),
+     *         State::Stopped => println!("Sound is stopped!")
+     *     }
+     *     Ok(())
      * }
      * ```
      */

--- a/src/sound_data.rs
+++ b/src/sound_data.rs
@@ -40,18 +40,17 @@ use sndfile::{SndFile, SndInfo};
  *
  * # Example
  * ```ignore
- * use ears::{Sound, SoundData, AudioController};
+ * use ears::{Sound, SoundData, SoundError, AudioController};
  * use std::cell::RefCell;
  * use std::rc::Rc;
  *
- * fn main() -> () {
+ * fn main() -> Result<(), SoundError> {
  *   // Create a SoundData
- *   let snd_data = Rc::new(RefCell::new(SoundData::new("path/to/my/sound.wav")
- *                                       .unwrap()));
+ *   let snd_data = Rc::new(RefCell::new(SoundData::new("path/to/my/sound.wav")?));
  *
  *   // Create two Sound with the same SoundData
- *   let mut snd1 = Sound::new_with_data(snd_data.clone()).unwrap();
- *   let mut snd2 = Sound::new_with_data(snd_data.clone()).unwrap();
+ *   let mut snd1 = Sound::new_with_data(snd_data.clone())?;
+ *   let mut snd2 = Sound::new_with_data(snd_data.clone())?;
  *
  *   // Play the sounds
  *   snd1.play();
@@ -59,6 +58,7 @@ use sndfile::{SndFile, SndInfo};
  *
  *   // Wait until snd2 is playing
  *   while snd2.is_playing() {}
+ *   Ok(())
  * }
  * ```
  */


### PR DESCRIPTION
This helps beginners use the API the correct way, instead of introducing panic everywhere in their code.

Also reexport needed error types.