### PR TITLE
Expose cleanup function as public

### DIFF
--- a/src/internal.rs
+++ b/src/internal.rs
@@ -211,7 +211,8 @@ impl OpenAlData {
     }
 }
 
-extern "C" fn cleanup_openal_context() {
+/// Does early cleanup of the library. This is automatically called when the program exits.
+pub fn cleanup() {
     if let Ok(mut guard) = AL_CONTEXT.lock() {
         if let Ok(ref mut context) = *guard {
             unsafe {
@@ -223,6 +224,9 @@ extern "C" fn cleanup_openal_context() {
             }
         }
     }
+}
+extern "C" fn cleanup_openal_context() {
+    cleanup()
 }
 
 macro_rules! check_openal_context(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub use audio_controller::AudioController;
 pub use audio_tags::{AudioTags, Tags};
 pub use einit::{init, init_in};
 pub use error::SoundError;
-pub use internal::OpenAlContextError;
+pub use internal::{cleanup, OpenAlContextError};
 pub use music::Music;
 pub use presets::ReverbPreset;
 pub use record_context::RecordContext;


### PR DESCRIPTION
This PR exposes a `cleanup` function as public (similar to the present `init` functions), which allows cleaning up early.

This makes stuff more customisable. In my game that uses bracket-lib, using the normal cleanup (which uses `libc::atexit`) makes the window hang when it's closing, for some reason, so I use this change to do the cleanup early and not leave the screen hanging.